### PR TITLE
Fixed lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
+      "pre-commit": "lint-staged --no-stash",
       "commit-msg": "commit-message-validator",
       "pre-push": "npm run build"
     }


### PR DESCRIPTION
--no-stash: By default a backup stash will be created before running the tasks, and all task modifications will be reverted in case of an error. This option will disable creating the stash, and instead leave all modifications in the index when aborting the commit.